### PR TITLE
Agressive backups

### DIFF
--- a/DataBaseClass.py
+++ b/DataBaseClass.py
@@ -36,3 +36,7 @@ class DataBase(object):
             return [x for x in filter(lambda x: x[0]>t,self.streams[id])]
         except:
             return []
+
+    def recordList(self):
+        return self.records.keys()
+    

--- a/DataBaseClass.py
+++ b/DataBaseClass.py
@@ -37,6 +37,5 @@ class DataBase(object):
         except:
             return []
 
-    def recordList(self):
+    def getRecords(self):
         return self.records.keys()
-    

--- a/LogicClass.py
+++ b/LogicClass.py
@@ -210,7 +210,7 @@ class DHTLogic(object):
 
     def onResponsibilityChange(self):
         #print("BACKUP IS HAPPENING")
-        records = list(self.database.recordList())
+        records = list(self.database.getRecords())
         ##print(records)
         rlocs = list(map(lambda x: space.idToPoint(2, x), records))
         ##print(rlocs)

--- a/NetworkClass.py
+++ b/NetworkClass.py
@@ -28,7 +28,7 @@ class Networking(object):
 		This function remotely calls seek on the remote node,
 		asking it to run LogicComponent.seek() on id
 		"""
-		path = remote.addr+"api/v0/peer/"+"seek/%s" % id 
+		path = remote.addr+"api/v0/peer/"+"seek/%s" % id
 		val = None
 		try:
 			r = requests.get(path)
@@ -58,10 +58,16 @@ class Networking(object):
 		#print("SENDING NOTIFY",remote,origin)
 		try:
 			r = requests.post(remote.addr+"api/v0/peer/notify", data=str(origin))
-			print("The Post Worked")
 			return r.status_code == requests.codes.ok
 		except:
-			print("The Post failed")
+			return False
+
+	def store(self,remote,id,data):
+		#print("SENDING NOTIFY",remote,origin)
+		try:
+			r = requests.post(remote.addr+"api/v0/client/store/"+id, data=data)
+			return r.status_code == requests.codes.ok
+		except:
 			return False
 
 
@@ -76,11 +82,9 @@ class Networking(object):
 
 	def ping(self,remote):
 		#print("SENDING NOTIFY",remote,origin)
-		print("ping")
 		try:
-			print("trying",remote.addr+"api/v0/peer/ping")
 			r = requests.get(remote.addr+"api/v0/peer/ping")
-			print(r.text)
+
 			return r.status_code == requests.codes.ok
 		except:
 			return False

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ if __name__=="__main__":
 	if args.config:
 		configpath = args.config
 	config = jsonLoad(configpath)
-	
+
 
 	ip = config["bindAddr"]
 	port = config["bindPort"]
@@ -48,7 +48,7 @@ if __name__=="__main__":
 
 
 	bootstraps = jsonLoad(config["bootstraps"])
-	
+
 	peerPool = [util.PeerInfo(x["id"],x["addr"],x["wsAddr"]) for x in bootstraps]
 
 	peerPool = list(filter(lambda x: net.ping(x), peerPool))#filter only living bootstrap peers
@@ -62,16 +62,16 @@ if __name__=="__main__":
 
 	hashid = genHash(path,0x12)
 
-	
+
 	myPeerInfo = util.PeerInfo(hashid,path, wsPath)
 
-	
+
 	logic = LogicClass.DHTLogic(myPeerInfo)
 
 	net.setup(logic,data)
 
-	logic.setup(net)
-	
+	logic.setup(net,data)
+
 
 	logic.join(peerPool)
 

--- a/server.py
+++ b/server.py
@@ -105,6 +105,8 @@ class RESTHandler(http.server.BaseHTTPRequestHandler):
             wsAddr = jsonDict["wsAddr"]
             myLogic.getNotified(PeerInfo(hashID,addr,wsAddr))
             self.wfile.write(b"[]")
+    def log_message(self, format, *args):
+        return
 
 def getThread(ip='0.0.0.0',port=8000):
     server = http.server.HTTPServer((ip,port), RESTHandler)


### PR DESCRIPTION
deals with issue #46 
Essentially, when my short peer list changes (my voronoi region changes), I check my records and backup all the records onto the nodes that will become responsible when I die.

This has the fun side effect of joining nodes being pre-loaded with the records for which they are responsible.

essentially, two nodes adjacent to each other in the network need to die together (in a small O(seconds) time window) in order for use to lose records.
