### PR TITLE
Revert "use the vendored version of the requests module"

### DIFF
--- a/websocketProxy.py
+++ b/websocketProxy.py
@@ -17,7 +17,7 @@ def main(wsBindAddr,wsBindPort,hostPath):
 	import asyncio
 	import websockets
 	import json
-	import myrequests
+	import requests
 
 	@asyncio.coroutine
 	def proxy(websocket, path):


### PR DESCRIPTION
Reverts UrDHT/PyUrDHT#59

did you test this? This won't work.

You are least need to make the edit into

```
import myrequests as requests
```
