### PR TITLE
Added new location features, removed websockets

### DIFF
--- a/LogicClass.py
+++ b/LogicClass.py
@@ -96,7 +96,11 @@ class DHTLogic(object):
         self.notifiedMe = []
         self.locPeerDict = {}
         self.info = peerInfo
-        self.loc = space.idToPoint(2, self.info.id)
+        if peerInfo.loc is None:
+            self.loc = space.idToPoint(2, self.info.id)
+            self.info.loc = self.loc
+        else:
+            self.loc = peerInfo.loc
         self.janitorThread = None
         self.peersLock = threading.Lock()
         self.notifiedLock = threading.Lock()

--- a/NetworkClass.py
+++ b/NetworkClass.py
@@ -33,7 +33,7 @@ class Networking(object):
 		try:
 			r = requests.get(path)
 			results = r.json()
-			val = util.PeerInfo(results["id"],results["addr"],results["wsAddr"])
+			val = util.PeerInfo(results["id"],results["addr"],results["loc"])
 		except Exception:
 			raise DialFailed()
 		return val
@@ -48,7 +48,7 @@ class Networking(object):
 			if len(r.json()) == 0:
 				return []
 			for p in r.json():
-				newPeer = util.PeerInfo(p["id"],p["addr"],p["wsAddr"])
+				newPeer = util.PeerInfo(p["id"],p["addr"],p["loc"])
 				result.append(newPeer)
 		except Exception:
 			raise DialFailed()
@@ -81,7 +81,6 @@ class Networking(object):
 		return ip
 
 	def ping(self,remote):
-		#print("SENDING NOTIFY",remote,origin)
 		try:
 			r = requests.get(remote.addr+"api/v0/peer/ping")
 

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,3 +1,3 @@
 [
-{"id":"QmZAanMgeVCDL4ohdgpPNBwv72G51HDzHGFgzRboF49Wo5", "addr":"http://45.79.205.125:8002/", "wsAddr":"ws:/45.79.205.125:8003"}
+  {"id":"QmcSMVU6QmUPaudoUVtQBcNmhQYqPmWgk7iwtWZbomYLso", "addr":"envy.blamestross.com:8000/", "loc":[0.051375,0.260523]}
 ]

--- a/bootstrap.json
+++ b/bootstrap.json
@@ -1,3 +1,3 @@
 [
-  {"id":"QmcSMVU6QmUPaudoUVtQBcNmhQYqPmWgk7iwtWZbomYLso", "addr":"envy.blamestross.com:8000/", "loc":[0.051375,0.260523]}
+  {"id":"QmRQfVhQ9pnKDZqRrxCb81XgLUhK6UM6hLwg6VHAV7v2o1", "addr":"http://envy.blamestross.com:8000/", "loc":[0.179322,0.359432]}
 ]

--- a/config.json
+++ b/config.json
@@ -4,6 +4,6 @@
 	"wsBindAddr":"0.0.0.0",
 	"wsBindPort":8001,
 	"bootstraps":"bootstrap.json",
-	"publicAddr":"http://73.207.38.249:8000/",
-	"wsAddr":"ws:/73.207.38.249:8001"
+	"publicAddr":"",
+	"wsAddr":""
 }

--- a/config.json
+++ b/config.json
@@ -1,9 +1,7 @@
 {
 	"bindAddr":"0.0.0.0",
 	"bindPort":8000,
-	"wsBindAddr":"0.0.0.0",
-	"wsBindPort":8001,
 	"bootstraps":"bootstrap.json",
 	"publicAddr":"",
-	"wsAddr":""
+	"loc":""
 }

--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ if __name__=="__main__":
 
 
 	path = config["publicAddr"]
-	if len(path) == 0 and len(peers) > 0:
+	if len(path) == 0 and len(peerPool) > 0:
 		random_peer = random.choice(peerPool)
 		pubip = net.getIP(random_peer)
 		path = "http://%s:%d/" % (pubip, port)

--- a/server.py
+++ b/server.py
@@ -76,6 +76,9 @@ class RESTHandler(http.server.BaseHTTPRequestHandler):
         if None != re.search('/api/v0/peer/ping*', self.path):
             self.wfile.write(b'\"PONG\"')
 
+        if None != re.search('/api/v0/peer/info*', self.path):
+            self.wfile.write(bytes(str(myLogic.info),"UTF-8"))
+
 
     def do_POST(self):
         self.do_HEAD()
@@ -102,8 +105,8 @@ class RESTHandler(http.server.BaseHTTPRequestHandler):
             jsonDict = json.loads(str(data,"UTF-8"))
             addr = jsonDict["addr"]
             hashID = jsonDict["id"]
-            wsAddr = jsonDict["wsAddr"]
-            myLogic.getNotified(PeerInfo(hashID,addr,wsAddr))
+            loc = jsonDict["loc"]
+            myLogic.getNotified(PeerInfo(hashID,addr,loc))
             self.wfile.write(b"[]")
     def log_message(self, format, *args):
         return

--- a/util.py
+++ b/util.py
@@ -5,17 +5,17 @@ class PeerInfo(object):
 
         right now UrDHT is not enforcing a mapping of hashIDs to servers
     """
-    def __init__(self,hashID,addr,wsAddr):
+    def __init__(self,hashID,addr,loc):
         """
             hashID is a string encoded in multihash format
             addr is whatever the network module needs to connect
         """
         self.id = hashID
         self.addr = addr
-        self.wsAddr = wsAddr
+        self.loc = loc
 
     def __str__(self):
-        return """{"id":"%s", "addr":"%s", "wsAddr":"%s"}"""%(self.id,self.addr,self.wsAddr)
+        return """{"id":"%s", "addr":"%s", "loc":[%f,%f]}"""%(self.id,self.addr,self.loc[0],self.loc[1])
 
     def __hash__(self):
         return hash((hash(self.id),hash(self.addr)))


### PR DESCRIPTION
We added location (in the metric space) as a part of nodeinfo.
We (currently) generate this location from using the hash of the public address as the seed for a PRNG.
This PRNG used is Mersenne Twister and the process is as follows (this part isn't new but I'll explain it for clarity):
- Convert hash into an int shaped thing
- seed the RNG with the integer
- Use the RNG to get x and y coordinates, which are each in the range [0.0, 1.0]

Envy is now using dns
